### PR TITLE
To fix ivy's bug :smile:

### DIFF
--- a/function-args.el
+++ b/function-args.el
@@ -47,6 +47,7 @@
 (require 'semantic/db-find)
 (require 'semantic-directory)
 (require 'json)
+(require 'ivy)
 (defvar ivy-last)
 (declare-function ivy-read "ext:ivy")
 (declare-function ivy-state-window "ext:ivy")


### PR DESCRIPTION
I've just noticed that function-args package doesn't seem to be properly working with ivy. Since, it's main function `ivy-set-actions` is being used. Ivy needs to be loaded in function-args package though.

Btw, here's a screenshot of the error https://imgur.com/ZM38KOk

@abo-abo Can you please review it and merge the pull request?

PS: So, I had to manually recompile and load the ivy's package in function-args to have this bug fixed! 